### PR TITLE
add Url.Builder.maybe for building URLs with Maybe String

### DIFF
--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -180,6 +180,22 @@ string : String -> String -> QueryParameter
 string key value =
   QueryParameter (Url.percentEncode key) (Url.percentEncode value)
 
+{-| Create a percent-encoded query parameter from a Maybe string.
+     absolute ["products"] [ maybe "search" (Just "hat") ]
+    -- "/products?search=hat&page=2"
+     absolute ["products"] [ maybe "search" Nothing ]
+        -- "/products?="
+ This is particularly useful if you don't want to send a key with an empty value.
+\*Note that a query parameter with an empty key value pair has no effect on URL.
+ -}
+maybe : String -> Maybe String -> QueryParameter
+maybe key value =
+    case value of
+      Just val ->
+        QueryParameter (Url.percentEncode key) (Url.percentEncode val)
+
+      Nothing ->
+          QueryParameter "" ""
 
 {-| Create a percent-encoded query parameter.
 

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -189,10 +189,10 @@ string key value =
 \*Note that a query parameter with an empty key value pair has no effect on URL.
  -}
 maybe : String -> Maybe String -> QueryParameter
-maybe key value =
-    case value of
-      Just val ->
-        QueryParameter (Url.percentEncode key) (Url.percentEncode val)
+maybe key maybeValue =
+    case maybeValue of
+      Just value ->
+        string key value
 
       Nothing ->
           QueryParameter "" ""


### PR DESCRIPTION
This PR is more an interest check than anything else - I've found myself needing to build URLs where some of the query parameters may or may not be added to the final URL, depending on the values. For example, an api with these routes: 

GET `/products?search=hat`
GET `/products`

Means we could have a case where we pass the search value as a `Maybe String` and use the `Url.Builder.maybe` like so:

``` 
import Url.Builder exposing (absolute, maybe)

absolute ["products"][ maybe "search" (Just hat)  ]
-- "/products?search=hat"
absolute ["products"][ maybe "search" Nothing  ]
-- "/products?="
```